### PR TITLE
Connecting Courses Page 

### DIFF
--- a/about.html
+++ b/about.html
@@ -42,7 +42,7 @@
             <div class="about-col">
                 <h1>Our university stands as the world's largest educational institution</h1>
                 <p>Welcome to our prestigious university, where academic excellence and innovation merge to shape future leaders. With a rich history, we empower students to reach their full potential and contribute to society. Our diverse community fosters collaboration, exploration, and boundaries. With state-of-the-art facilities and world-renowned faculty, we provide a dynamic learning environment. Join us for academic journeys or career advancements to become part of our legacy of excellence.</p>
-                <a href="" class="hero-btn red-btn">EXPLORE NOW</a>
+                <a href="course.html" class="hero-btn red-btn">EXPLORE NOW</a>
             </div>
             <div class="about-col">
                 <img src="./eduford_img/about.jpg" alt="">


### PR DESCRIPTION
This pull request adds a link to the "Courses" page within the website.

Functionality: The courses page is now connected with the Explore More button in the Hero Section of the About Us page.
Implementation: The page was connected using anchor tag.
Testing: I have manually tested the connection of the pages.


<img width="938" alt="eduford_beforepage" src="https://github.com/juhinagpure/Eduford-university/assets/130893914/e1139eec-34df-40f7-b063-6760c028c56c">



<img width="941" alt="eduford_afterpage" src="https://github.com/juhinagpure/Eduford-university/assets/130893914/d0b58925-8d25-43f2-881d-3f9c9d1babea">
