### PR TITLE
style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,12 +2,16 @@
     margin: 0;
     padding: 0;
     font-family: 'Poppins', sans-serif;
-    
+               
    
   
 }
+:root {
+    --nav-height: 49px; 
+  }
 body{
     overflow-x: hidden;
+    scroll-padding-top: var(--nav-height);
     
 }
 
@@ -23,55 +27,65 @@ body{
 }
 
 nav {
-  display: flex;
-  width: 100%;
-  padding: 2% 6%;
-  text-align: center;
-  justify-content: space-around;
-  align-items: center;
-  position: fixed;
-  background-image: linear-gradient(rgba(4, 9, 30, 0.7), rgba(4, 9, 30, 0.7));
-}
-
-nav img {
+    display: flex;
+    width: 100%;
+    padding: 2% 6%;
+    text-align: center;
+    justify-content: space-around;
+    align-items: center;
+    position: fixed;
+    top: 0; 
+    left: 0;
+    background-image: linear-gradient(rgba(4, 9, 30, 0.7), rgba(4, 9, 30, 0.7));
+    z-index: 1000; 
+    height: var(--nav-height);
+  }
+  
+  nav img {
     width: 150px;
-}
-
-.nav-links {
+  }
+  
+  .nav-links {
     flex: 1;
     text-align: right;
-}
-
-.nav-links ul li {
+  }
+  
+  .nav-links ul {
+    padding: 0;
+    margin: 0;
     list-style: none;
+  }
+  
+  .nav-links ul li {
     display: inline-block;
     padding: 8px 12px;
     position: relative;
-}
-
-.nav-links ul li a {
+  }
+  
+  .nav-links ul li a {
     color: #fff;
     text-decoration: none;
     font-size: 13px;
-}
-
-.nav-links ul li::after {
+  }
+  
+  .nav-links ul li::after {
     content: '';
-    width: 0%;
+    width: 0;
     height: 2px;
     background: #f44336;
     display: block;
     margin: auto;
-    transition: 0.5s;
-}
-
-.nav-links ul li:hover::after {
+    transition: width 0.5s;
+  }
+  
+  .nav-links ul li:hover::after {
     width: 100%;
-}
-
-.nav-links ul li:clicked {
+  }
+  
+  /* Use :active pseudo-class for the click effect */
+  .nav-links ul li:active a {
     text-decoration: underline;
-}
+  }
 
 .text-box {
     width: 90%;


### PR DESCRIPTION
#37 We updated the CSS to ensure the navigation bar has a consistent linear gradient background across all pages by linking a common `styles.css` file in each HTML file. The CSS sets the `nav` element as fixed with a gradient background, appropriate padding, and ensures it stays on top using `z-index`. We also added styles for alignment, hover effects, and box shadow for depth.